### PR TITLE
feat(error): Display human error when API key ACL is not enough

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,9 @@ I suggest updating the website `Gemfile` to point to the correct local directory
 ```ruby
 gem "algoliasearch-jekyll", :path => "/path/to/local/gem/folder"
 ```
+You should also run `rake gemspec` from the `algoliasearch-jekyll` repository if
+you added new files or dependencies.
+
 
 If you plan on submitting a PR, I suggest you install the git hooks. This will
 run pre-commit and pre-push checks. Those checks will also be run by TravisCI,

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,10 @@ source 'http://rubygems.org'
 gem 'algoliasearch', '~> 1.4'
 gem 'appraisal', '~> 2.1.0'
 gem 'awesome_print', '~> 1.6'
+gem 'jekyll', '~> 2.5'
 gem 'json', '~> 1.8'
 gem 'nokogiri', '~> 1.6'
+gem 'verbal_expressions', '~> 0.1.5'
 
 group :development do
   gem 'coveralls', '~> 0.8'

--- a/Guardfile
+++ b/Guardfile
@@ -1,17 +1,7 @@
-group :jekyll_v3 do
-  guard :rspec, cmd: 'appraisal jekyll-v3 bundle exec rspec --color --format documentation' do
-    watch(%r{^spec/.+_spec\.rb$})
-    watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
-    watch('spec/spec_helper.rb')  { 'spec' }
-  end
-end
-
-group :jekyll_v2 do
-  guard :rspec, cmd: 'appraisal jekyll-v2 bundle exec rspec --color --format documentation' do
-    watch(%r{^spec/.+_spec\.rb$})
-    watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
-    watch('spec/spec_helper.rb')  { 'spec' }
-  end
+guard :rspec, cmd: 'bundle exec rspec --color --format documentation' do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { 'spec' }
 end
 
 notification :off

--- a/algoliasearch-jekyll.gemspec
+++ b/algoliasearch-jekyll.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
     "gemfiles/jekyll_v3.gemfile",
     "lib/algoliasearch-jekyll.rb",
     "lib/credential_checker.rb",
+    "lib/error_handler.rb",
     "lib/push.rb",
     "lib/record_extractor.rb",
     "lib/version.rb",
@@ -53,6 +54,7 @@ Gem::Specification.new do |s|
     "scripts/watch_v2",
     "scripts/watch_v3",
     "spec/credential_checker_spec.rb",
+    "spec/error_handler_spec.rb",
     "spec/fixtures/jekyll_version_2/_config.yml",
     "spec/fixtures/jekyll_version_2/_layouts/default.html",
     "spec/fixtures/jekyll_version_2/_my-collection/collection-item.html",
@@ -89,7 +91,8 @@ Gem::Specification.new do |s|
     "spec/spec_helper_simplecov.rb",
     "txt/api_key_missing",
     "txt/application_id_missing",
-    "txt/index_name_missing"
+    "txt/index_name_missing",
+    "txt/sample"
   ]
   s.homepage = "https://github.com/algolia/algoliasearch-jekyll"
   s.licenses = ["MIT"]
@@ -103,8 +106,10 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<algoliasearch>, ["~> 1.4"])
       s.add_runtime_dependency(%q<appraisal>, ["~> 2.1.0"])
       s.add_runtime_dependency(%q<awesome_print>, ["~> 1.6"])
+      s.add_runtime_dependency(%q<jekyll>, ["~> 2.5"])
       s.add_runtime_dependency(%q<json>, ["~> 1.8"])
       s.add_runtime_dependency(%q<nokogiri>, ["~> 1.6"])
+      s.add_runtime_dependency(%q<verbal_expressions>, ["~> 0.1.5"])
       s.add_development_dependency(%q<coveralls>, ["~> 0.8"])
       s.add_development_dependency(%q<flay>, ["~> 2.6"])
       s.add_development_dependency(%q<flog>, ["~> 4.3"])
@@ -117,8 +122,10 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<algoliasearch>, ["~> 1.4"])
       s.add_dependency(%q<appraisal>, ["~> 2.1.0"])
       s.add_dependency(%q<awesome_print>, ["~> 1.6"])
+      s.add_dependency(%q<jekyll>, ["~> 2.5"])
       s.add_dependency(%q<json>, ["~> 1.8"])
       s.add_dependency(%q<nokogiri>, ["~> 1.6"])
+      s.add_dependency(%q<verbal_expressions>, ["~> 0.1.5"])
       s.add_dependency(%q<coveralls>, ["~> 0.8"])
       s.add_dependency(%q<flay>, ["~> 2.6"])
       s.add_dependency(%q<flog>, ["~> 4.3"])
@@ -132,8 +139,10 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<algoliasearch>, ["~> 1.4"])
     s.add_dependency(%q<appraisal>, ["~> 2.1.0"])
     s.add_dependency(%q<awesome_print>, ["~> 1.6"])
+    s.add_dependency(%q<jekyll>, ["~> 2.5"])
     s.add_dependency(%q<json>, ["~> 1.8"])
     s.add_dependency(%q<nokogiri>, ["~> 1.6"])
+    s.add_dependency(%q<verbal_expressions>, ["~> 0.1.5"])
     s.add_dependency(%q<coveralls>, ["~> 0.8"])
     s.add_dependency(%q<flay>, ["~> 2.6"])
     s.add_dependency(%q<flog>, ["~> 4.3"])

--- a/gemfiles/jekyll_v2.gemfile
+++ b/gemfiles/jekyll_v2.gemfile
@@ -5,9 +5,10 @@ source "http://rubygems.org"
 gem "algoliasearch", "~> 1.4"
 gem "appraisal", "~> 2.1.0"
 gem "awesome_print", "~> 1.6"
+gem "jekyll", "~> 2.5"
 gem "json", "~> 1.8"
 gem "nokogiri", "~> 1.6"
-gem "jekyll", "~> 2.5"
+gem "verbal_expressions", "~> 0.1.5"
 
 group :development do
   gem "coveralls", "~> 0.8"

--- a/gemfiles/jekyll_v3.gemfile
+++ b/gemfiles/jekyll_v3.gemfile
@@ -5,9 +5,10 @@ source "http://rubygems.org"
 gem "algoliasearch", "~> 1.4"
 gem "appraisal", "~> 2.1.0"
 gem "awesome_print", "~> 1.6"
+gem "jekyll", "~> 3.0"
 gem "json", "~> 1.8"
 gem "nokogiri", "~> 1.6"
-gem "jekyll", "~> 3.0"
+gem "verbal_expressions", "~> 0.1.5"
 gem "jekyll-paginate", "~> 1.1.0"
 
 group :development do

--- a/lib/credential_checker.rb
+++ b/lib/credential_checker.rb
@@ -1,13 +1,15 @@
 require 'algoliasearch'
 require 'nokogiri'
 require 'json'
+require_relative './error_handler.rb'
 
 # Given an HTML file as input, will return an array of records to index
 class AlgoliaSearchCredentialChecker
-  attr_accessor :config
+  attr_accessor :config, :logger
 
   def initialize(config)
     @config = config
+    @logger = AlgoliaSearchErrorHandler.new
   end
 
   # Read the API key either from ENV or from an _algolia_api_key file in
@@ -24,36 +26,24 @@ class AlgoliaSearchCredentialChecker
     nil
   end
 
-  def display_error(file)
-    file = File.expand_path(File.join(File.dirname(__FILE__), '../txt', file))
-    content = File.open(file).readlines.map(&:chomp)
-    content.each_with_index do |line, index|
-      if index == 0
-        Jekyll.logger.error line
-        next
-      end
-      Jekyll.logger.warn line
-    end
-  end
-
   # Check that the API key is available
   def check_api_key
     return if api_key
-    display_error('api_key_missing')
+    @logger.display('api_key_missing')
     exit 1
   end
 
   # Check that the application id is defined
   def check_application_id
     return if @config['algolia'] && @config['algolia']['application_id']
-    display_error('application_id_missing')
+    @logger.display('application_id_missing')
     exit 1
   end
 
   # Check that the index name is defined
   def check_index_name
     return if @config['algolia'] && @config['algolia']['index_name']
-    display_error('index_name_missing')
+    @logger.display('index_name_missing')
     exit 1
   end
 

--- a/lib/error_handler.rb
+++ b/lib/error_handler.rb
@@ -1,0 +1,87 @@
+require 'json'
+require 'verbal_expressions'
+
+# Helps in displaying useful error messages to users, to help them debug their
+# issues
+class AlgoliaSearchErrorHandler
+  # Will output the specified error file.
+  # First line is displayed as error, next ones as warning
+  def display(file)
+    file = File.expand_path(File.join(File.dirname(__FILE__), '../txt', file))
+    content = File.open(file).readlines.map(&:chomp)
+    content.each_with_index do |line, index|
+      if index == 0
+        Jekyll.logger.error line
+        next
+      end
+      Jekyll.logger.warn line
+    end
+  end
+
+  def error_tester
+    # Ex: Cannot PUT to https://appid.algolia.net/1/indexes/index_name/settings:
+    # {"message":"Invalid Application-ID or API key","status":403} (403)
+    VerEx.new do
+      find 'Cannot '
+      capture('verb') { word }
+      find ' to '
+      capture('scheme') { word }
+      find '://'
+      capture('app_id') { word }
+      anything_but '/'
+      find '/'
+      capture('api_version') { digit }
+      find '/'
+      capture('api_section') { word }
+      find '/'
+      capture('index_name') { word }
+      find '/'
+      capture('api_action') { word }
+      find ': '
+      capture('json') do
+        find '{'
+        anything_but('}')
+        find '}'
+      end
+      find ' ('
+      capture('http_error') { word }
+      find ')'
+    end
+  end
+
+  def parse_algolia_error(error)
+    error.gsub!("\n", '')
+
+    tester = error_tester
+    matches = tester.match(error)
+
+    return false unless matches
+
+    hash = {}
+    matches.names.each do |match|
+      hash[match] = matches[match]
+    end
+
+    # Cast integers
+    hash['api_version'] = hash['api_version'].to_i
+    hash['http_error'] = hash['http_error'].to_i
+
+    # Parse JSON
+    hash['json'] = JSON.parse(hash['json'])
+
+    hash
+  end
+
+  # Given an Algolia API error message, will return the best error message
+  def readable_algolia_error(error)
+    error = parse_algolia_error(error)
+    return false unless error
+
+    # Given API key does not have rights on the _tmp index
+    if error['http_error'] == 403 && error['index_name'] =~ /_tmp$/
+      return 'check_key_acl_to_tmp_index'
+    end
+
+    false
+  end
+end

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
-cd "$(dirname "$BASH_SOURCE")"/..
 
-echo "Testing under Jekyll 2.5"
 COVERAGE=1 appraisal jekyll-v2 bundle exec rspec

--- a/scripts/test_ci
+++ b/scripts/test_ci
@@ -4,4 +4,4 @@
 # worrying about appraisal
 cd "$(dirname "$BASH_SOURCE")"/..
 
-bundle exec rspec
+COVERAGE=1 bundle exec rspec

--- a/scripts/test_v3
+++ b/scripts/test_v3
@@ -2,5 +2,5 @@
 cd "$(dirname "$BASH_SOURCE")"/..
 
 echo "Testing under Jekyll 3.0"
-appraisal jekyll-v3 bundle exec rspec
+COVERAGE=1 appraisal jekyll-v3 bundle exec rspec
 

--- a/scripts/watch_v2
+++ b/scripts/watch_v2
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 cd "$(dirname "$BASH_SOURCE")"/..
 
-guard -g jekyll_v2
+appraisal jekyll-v2 guard 

--- a/scripts/watch_v3
+++ b/scripts/watch_v3
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 cd "$(dirname "$BASH_SOURCE")"/..
 
-guard -g jekyll_v3
+appraisal jekyll-v3 guard 

--- a/spec/credential_checker_spec.rb
+++ b/spec/credential_checker_spec.rb
@@ -60,14 +60,16 @@ describe(AlgoliaSearchCredentialChecker) do
   end
 
   describe 'assert_valid' do
+    before(:each) do
+      allow(checker.logger).to receive(:display)
+    end
     it 'should display error if no api key' do
       # Given
-      allow(checker).to receive(:api_key) { nil }
+      allow(checker).to receive(:api_key).and_return nil
 
       # Then
-      expect(Jekyll.logger).to receive(:error).with(/api key/i)
-      expect(Jekyll.logger).to receive(:warn).at_least(:once)
       expect(-> { checker.assert_valid }).to raise_error SystemExit
+      expect(checker.logger).to have_received(:display).with('api_key_missing')
     end
 
     it 'should display error if no application id' do
@@ -79,9 +81,10 @@ describe(AlgoliaSearchCredentialChecker) do
       stub_const('ENV', 'ALGOLIA_API_KEY' => 'APIKEY_FROM_ENV')
 
       # Then
-      expect(Jekyll.logger).to receive(:error).with(/application id/i)
-      expect(Jekyll.logger).to receive(:warn).at_least(:once)
       expect(-> { checker.assert_valid }).to raise_error SystemExit
+      expect(checker.logger)
+        .to have_received(:display)
+        .with('application_id_missing')
     end
 
     it 'should display error if no index name' do
@@ -93,9 +96,10 @@ describe(AlgoliaSearchCredentialChecker) do
       stub_const('ENV', 'ALGOLIA_API_KEY' => 'APIKEY_FROM_ENV')
 
       # Then
-      expect(Jekyll.logger).to receive(:error).with(/index name/i)
-      expect(Jekyll.logger).to receive(:warn).at_least(:once)
       expect(-> { checker.assert_valid }).to raise_error SystemExit
+      expect(checker.logger)
+        .to have_received(:display)
+        .with('index_name_missing')
     end
 
     it 'should init the Algolia client' do

--- a/spec/error_handler_spec.rb
+++ b/spec/error_handler_spec.rb
@@ -1,0 +1,150 @@
+require 'spec_helper'
+
+describe(AlgoliaSearchErrorHandler) do
+  before(:each) do
+    @error_handler = AlgoliaSearchErrorHandler.new
+  end
+
+  describe 'display' do
+    before(:each) do
+      allow(Jekyll.logger).to receive(:error)
+      allow(Jekyll.logger).to receive(:warn)
+    end
+
+    it 'should display first line as error' do
+      # Given
+      input = 'sample'
+
+      # When
+      @error_handler.display(input)
+
+      # Then
+      expect(Jekyll.logger).to have_received(:error).exactly(1).times
+    end
+
+    it 'should display all other lines as warnings' do
+      # Given
+      input = 'sample'
+
+      # When
+      @error_handler.display(input)
+
+      # Then
+      expect(Jekyll.logger).to have_received(:warn).exactly(3).times
+    end
+  end
+
+  describe 'parse_algolia_error' do
+    before(:each) do
+      @algolia_error = 'Cannot PUT to ' \
+        'https://appid.algolia.net/1/indexes/index_name/settings: ' \
+        '{"message":"Invalid Application-ID or API key","status":403} (403)'
+    end
+
+    it 'should extract all the url parts' do
+      # Given
+      input = @algolia_error
+
+      # When
+      actual = @error_handler.parse_algolia_error(input)
+
+      # Then
+      expect(actual['verb']).to eq 'PUT'
+      expect(actual['scheme']).to eq 'https'
+      expect(actual['app_id']).to eq 'appid'
+      expect(actual['api_section']).to eq 'indexes'
+      expect(actual['index_name']).to eq 'index_name'
+      expect(actual['api_action']).to eq 'settings'
+    end
+
+    it 'should cast integers to integers' do
+      # Given
+      input = @algolia_error
+
+      # When
+      actual = @error_handler.parse_algolia_error(input)
+
+      # Then
+      expect(actual['api_version']).to eq 1
+      expect(actual['http_error']).to eq 403
+    end
+
+    it 'should parse the JSON part' do
+      # Given
+      input = @algolia_error
+
+      # When
+      actual = @error_handler.parse_algolia_error(input)
+
+      # Then
+      expect(actual['json']).to be_a(Hash)
+      expect(actual['json']['status']).to eq 403
+    end
+
+    it 'should return false if this is not parsable' do
+      # Given
+      input = 'foo bar baz'
+
+      # When
+      actual = @error_handler.parse_algolia_error(input)
+
+      # Then
+      expect(actual).to eq(false)
+    end
+
+    it 'should work on multiline errors' do
+      # Given
+      input = @algolia_error.gsub('}', "}\n")
+
+      # When
+      actual = @error_handler.parse_algolia_error(input)
+
+      # Then
+      expect(actual).to be_a(Hash)
+      expect(actual['http_error']).to eq 403
+    end
+  end
+
+  describe 'readable_algolia_error' do
+    it 'should warn about key ACL' do
+      # Given
+      parsed = {
+        'http_error' => 403,
+        'index_name' => 'something_tmp'
+      }
+      allow(@error_handler).to receive(:parse_algolia_error).and_return(parsed)
+
+      # When
+      actual = @error_handler.readable_algolia_error('error')
+
+      # Then
+      expect(actual).to eq('check_key_acl_to_tmp_index')
+    end
+
+    it 'should return false if no nice message found' do
+      # Given
+      parsed = false
+      allow(@error_handler).to receive(:parse_algolia_error).and_return(parsed)
+
+      # When
+      actual = @error_handler.readable_algolia_error('error')
+
+      # Then
+      expect(actual).to eq(false)
+    end
+
+    it 'should return false if message does not match any known case' do
+      # Given
+      parsed = {
+        'http_error' => 42
+      }
+      allow(@error_handler).to receive(:parse_algolia_error).and_return(parsed)
+
+      # When
+      actual = @error_handler.readable_algolia_error('error')
+
+      # Then
+      expect(actual).to eq(false)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require './lib/push.rb'
 
 RSpec.configure do |config|
   config.filter_run(focus: true)
+  config.fail_fast = true
   config.run_all_when_everything_filtered = true
 end
 

--- a/txt/check_key_acl_to_tmp_index
+++ b/txt/check_key_acl_to_tmp_index
@@ -1,0 +1,9 @@
+Algolia Error: API key cannot write to `{index_name}_tmp` index
+  In order to do atomic pushes to your Algolia index, the plugin first pushes to
+  a temporary index (suffixed with `_tmp`), then renames it.
+
+  You see this error because the plugin wasn't able to push to that 
+  `{index_name}_tmp` index, with the API key you provided.
+
+  Make sure the API key you're using has rights to write on both your index and
+  its `{index_name}_tmp` suffixed version.

--- a/txt/sample
+++ b/txt/sample
@@ -1,0 +1,4 @@
+Algolia Error: Sample Error
+This is where you can explain the error and:
+    - one way to fix it
+    - or another way to fix it


### PR DESCRIPTION
I've mostly added an ErrorHandler that groups all the error-related functions, including one that can parse the Algolia error messages in ordre to provide context-aware and more friendly error messages.

I've update the gemspec (in order to test the plugin in a real project)

I've also fixed a few misconfiguration with Appraisal. Running Guard will stop restarting the whole Appraisal process, Guard is now actually run from inside an Appraisal context. I've also set jekyll 2.5 as the defaul version (in Gemfile) and update it in specific Appraisals.
