### PR TITLE
Add a config option for extra extensions to index

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ algolia:
   record_css_selector: 'p,ul'
 ```
 
+#### `allowed_extensions`
+
+Define additional extensions to be indexed. The default behaviour is to index
+only markdown and HTML files.
+
+```yml
+algolia:
+  allowed_extensions:
+    - adoc
+    - ad
+```
+
 #### `settings`
 
 Here you can pass any specific [index settings][5] to your Algolia index. All

--- a/lib/push.rb
+++ b/lib/push.rb
@@ -41,6 +41,9 @@ class AlgoliaSearchJekyllPush < Jekyll::Command
       if @config['markdown_ext']
         allowed_extensions += @config['markdown_ext'].split(',')
       end
+      if @config['algolia']
+        allowed_extensions += (@config['algolia']['allowed_extensions'] || [])
+      end
       return false unless allowed_extensions.include?(extname)
 
       return false if excluded_file?(file)


### PR DESCRIPTION
Jekyll can be extended to parse file formats other than markdown.
However, `jekyll algolia push` ignores them by default. This adds
a config option to specify additional extensions to be indexed.

fixes #61 