### PR TITLE
Better too large error

### DIFF
--- a/lib/push.rb
+++ b/lib/push.rb
@@ -139,8 +139,8 @@ class AlgoliaSearchJekyllPush < Jekyll::Command
     end
 
     # Display the error in a human-friendly way if possible
-    def display_error(error, batch)
-      if error.message =~ /"message":\s*"Record at the position/
+    def display_error(error, batch = nil)
+      if batch.present? && error.message =~ /"message":\s*"Record at the position/
         idx = /Record at the position (\d+) is/.match(error.message)[1].to_i
         record = batch[idx.to_i]
         Jekyll.logger.error 'Algolia Error: Record too big'

--- a/lib/push.rb
+++ b/lib/push.rb
@@ -145,6 +145,7 @@ class AlgoliaSearchJekyllPush < Jekyll::Command
         record = batch[idx.to_i]
         Jekyll.logger.error 'Algolia Error: Record too big'
         Jekyll.logger.warn "Record path: #{record[:url]} § #{record[:unique_hierarchy]}"
+        Jekyll.logger.warn "Contents: #{record[:text][0...50]}..."
         return
       end
 

--- a/lib/push.rb
+++ b/lib/push.rb
@@ -139,7 +139,15 @@ class AlgoliaSearchJekyllPush < Jekyll::Command
     end
 
     # Display the error in a human-friendly way if possible
-    def display_error(error)
+    def display_error(error, batch)
+      if error.message =~ /"message":\s*"Record at the position/
+        idx = /Record at the position (\d+) is/.match(error.message)[1].to_i
+        record = batch[idx.to_i]
+        Jekyll.logger.error 'Algolia Error: Record too big'
+        Jekyll.logger.warn "Record path: #{record[:url]} § #{record[:unique_hierarchy]}"
+        return
+      end
+
       error_handler = AlgoliaSearchErrorHandler.new
       readable_error = error_handler.readable_algolia_error(error.message)
 
@@ -172,7 +180,7 @@ class AlgoliaSearchJekyllPush < Jekyll::Command
         begin
           index.add_objects!(batch) unless @is_dry_run
         rescue StandardError => error
-          display_error(error)
+          display_error(error, batch)
           exit 1
         end
       end


### PR DESCRIPTION
I was having an issue where the push failed, but I couldn’t figure out which record was causing the problem. It turned out to be a large `ul` (I fixed the issue by indexing `p,li` instead of `p,ul`), but there was no way to tell that from this message:

```
Algolia Error: HTTP Error 
Cannot POST to https://XXXXX.algolia.net/1/indexes/main-search_tmp/batch: {"message":"Record at the position 281 is too big size=10406 bytes. Contact us if you need an extended quota","position":281,"status":400} (400)
```

Now, it will output something like this:

```
Algolia Error: Record too big 
Record path: /smokey/Commands.html § Privileged commands
Content: 
 !!/report &lt;post URL 1&gt; [&lt;post URL 2&gt;...